### PR TITLE
Peg Grafana to 10.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   grafana:
-    image: grafana/grafana-oss:latest
+    image: grafana/grafana-oss:10.0.1
     container_name: grafana
     volumes:
       - grafana_data:/var/lib/grafana


### PR DESCRIPTION
Since Grafana is a fast changing front-end, I would recommend setting a current version and leap-frogging when a new stable version comes along.