### PR TITLE
bump grafana to 10.2.2 for incremental query, add chrpoxy for clickhouse caching

### DIFF
--- a/chproxy/config/config.yaml
+++ b/chproxy/config/config.yaml
@@ -1,0 +1,34 @@
+log_debug: false
+hack_me_please: true
+
+server:
+  http:
+    listen_addr: "0.0.0.0:9001"
+
+users:
+  - name: "qryn"
+    password: "demo"
+    to_cluster: "clickhouse-server"
+    to_user: "qryn"
+    max_concurrent_queries: 1000
+    max_execution_time: 30s
+    cache: "default_cache"
+
+clusters:
+  - name: "clickhouse-server"
+    nodes: [
+      "clickhouse-server:8123"
+    ]
+    users:
+      - name: "qryn"
+        password: "demo"
+
+caches:
+  - name: "default_cache"
+    mode: "file_system"
+    file_system:
+      dir: "/data/cache"
+      max_size: 2Gb
+    max_payload_size: 2Gb
+    shared_with_all_users: true
+    expire: 1h

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   grafana:
-    image: grafana/grafana-oss:10.0.1
+    image: grafana/grafana-oss:10.2.2
     container_name: grafana
     volumes:
       - grafana_data:/var/lib/grafana
@@ -24,7 +24,25 @@ services:
     ports:
       - 3000:3000
     depends_on:
-      - clickhouse-server
+      - qryn
+
+  chproxy:
+    image: contentsquareplatform/chproxy:v1.25.0
+    container_name: chproxy
+    volumes:
+      - ./chproxy/config:/config
+      - ./chproxy/cache:/data/cache
+    ports:
+      - 9001:9001
+    command: -config /config/config.yaml
+    depends_on:
+      clickhouse-server:
+        condition: service_healthy
+    healthcheck:
+      test: curl 'http://127.0.0.1:9001/metrics'
+      interval: 2s
+      timeout: 20s
+      retries: 10
 
   clickhouse-server:
     image: clickhouse/clickhouse-server:22.9
@@ -54,14 +72,17 @@ services:
     ports:
       - "3100:3100"
     environment:
-      - CLICKHOUSE_SERVER=clickhouse-server
+      - CLICKHOUSE_SERVER=chproxy
+      - CLICKHOUSE_PORT=9001
       - CLICKHOUSE_AUTH=qryn:demo
 #      - LOG_LEVEL=debug
       - NODE_OPTIONS="--max-old-space-size=4096"
       - ALERTMAN_URL=http://alertman:9093
     depends_on:
-       clickhouse-server:
-         condition: service_healthy
+      chproxy:
+        condition: service_healthy
+      clickhouse-server:
+        condition: service_healthy
 
   vector:
     image: timberio/vector:latest-alpine

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -62,6 +62,9 @@ datasources:
       graphiteVersion: "1.1"
       tlsAuth: false
       tlsAuthWithCACert: false
+      cacheLevel: 'High'
+      incrementalQuerying: 'Enable'
+      incrementalQueryOverlapWindow: 2m
   - name: Flux
     type: influxdb
     uid: flux


### PR DESCRIPTION
This fix will help when requesting a large number of metrics via qryn