### PR TITLE
Added logging limits for all containers to avoid filling up hosts

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -30,6 +30,11 @@ services:
       - 3000:3000
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   chproxy:
     image: contentsquareplatform/chproxy:v1.25.0
@@ -50,6 +55,11 @@ services:
       interval: 2s
       timeout: 20s
       retries: 10
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   clickhouse-server:
     image: clickhouse/clickhouse-server:24.1
@@ -71,6 +81,11 @@ services:
       interval: 1s
       timeout: 1s
       retries: 30
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   qryn:
     image: qxip/qryn:latest
@@ -97,6 +112,11 @@ services:
         condition: service_healthy
       clickhouse-server:
         condition: service_healthy
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   mailhog:
     image: mailhog/mailhog:latest
@@ -109,6 +129,11 @@ services:
       - 8025
     ports:
       - "8025:8025"
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
       
   alertman:
     image: prom/alertmanager:latest
@@ -122,6 +147,11 @@ services:
       - 9093
     ports:
       - 9093:9093
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   otel-collector:
     container_name: otel-collector
@@ -147,3 +177,8 @@ services:
       - "8086:8086"     # InfluxDB Line proto HTTP
       - "8062:8062"     # Pyroscope jprof
     restart: on-failure
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"

--- a/docker-compose-cloud.yml
+++ b/docker-compose-cloud.yml
@@ -24,6 +24,11 @@ services:
       - 3000:3000
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   qryn:
     image: qxip/qryn:latest
@@ -40,6 +45,11 @@ services:
       - CLICKHOUSE_AUTH=default:YOURPASSWORD
       - NODE_OPTIONS="--max-old-space-size=4096"
       - ALERTMAN_URL=http://alertman:9093
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   fluxpipe:
     image: ghcr.io/metrico/fluxpipe:latest
@@ -51,6 +61,11 @@ services:
       - "8086:8086"
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   vector:
     image: timberio/vector:latest-alpine
@@ -60,6 +75,11 @@ services:
       - ./vector/vector.toml:/etc/vector/vector.toml:ro
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   exporter:
     build: ./dummy-exporter
@@ -69,6 +89,11 @@ services:
       - "9090:8080"
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   dummy-server:
     build: ./dummy-server
@@ -79,6 +104,11 @@ services:
       - 80:80
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   mailhog:
     image: mailhog/mailhog:latest
@@ -89,6 +119,11 @@ services:
       - 8025
     ports:
       - "8025:8025"
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
       
   alertman:
     image: prom/alertmanager:latest
@@ -100,3 +135,8 @@ services:
       - 9093
     ports:
       - 9093:9093
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,11 @@ services:
       - 3000:3000
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   chproxy:
     image: contentsquareplatform/chproxy:v1.25.0
@@ -50,6 +55,11 @@ services:
       interval: 2s
       timeout: 20s
       retries: 10
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   clickhouse-server:
     image: clickhouse/clickhouse-server:24.1
@@ -72,6 +82,11 @@ services:
       interval: 1s
       timeout: 1s
       retries: 30
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   qryn:
     image: qxip/qryn:latest
@@ -98,6 +113,11 @@ services:
         condition: service_healthy
       clickhouse-server:
         condition: service_healthy
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   vector:
     image: timberio/vector:latest-alpine
@@ -109,6 +129,11 @@ services:
       - ./vector/vector.toml:/etc/vector/vector.toml:ro
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   exporter:
     build: ./dummy-exporter
@@ -120,6 +145,11 @@ services:
       - "9090:8080"
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   dummy-server:
     build: ./dummy-server
@@ -132,6 +162,11 @@ services:
       - 80:80
     depends_on:
       - qryn
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   mailhog:
     image: mailhog/mailhog:latest
@@ -144,6 +179,11 @@ services:
       - 8025
     ports:
       - "8025:8025"
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
       
   alertman:
     image: prom/alertmanager:latest
@@ -157,6 +197,11 @@ services:
       - 9093
     ports:
       - 9093:9093
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
 
   otel-collector:
     container_name: otel-collector
@@ -182,6 +227,11 @@ services:
       - "8086:8086"     # InfluxDB Line proto HTTP
       - "8062:8062"     # Pyroscope jprof
     restart: on-failure
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"
     
   alloy:
     privileged: true
@@ -209,3 +259,8 @@ services:
       - --stability.level=experimental # Enable all functionality
     ports:
       - "12345:12345"
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "5"


### PR DESCRIPTION
To avoid having hosts run out of memory because of container logs, I recommend we add logging limits to all containers.
This PR contains the necessary changes.