### PR TITLE
Collecting log via vector is fixed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,8 @@ services:
       - gigapipe-oss
     volumes:
       - ./vector/vector.toml:/etc/vector/vector.toml:ro
+    environment:
+      - VECTOR_CONFIG=/etc/vector/vector.toml
     depends_on:
       - gigapipe
     logging:


### PR DESCRIPTION
- Added env variable `VECTOR_CONFIG` to docker-compose to load vector with correct `.toml` config. By default it's `.yaml`